### PR TITLE
Add Statamic Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ class ShowContact extends Component
 
 The [Official Livewire documentation](https://laravel-livewire.com/docs/rendering-components)
 
+### Statamic Context
+Add the `WithContext` trait to your component to make the Statamic context available as public property.
+
+```php
+use Jonassiewertsen\Livewire\WithContext;
+
+class ShowContact extends Component
+{
+    use WithContext;
+
+    ...
+}
+```
+
+
 ### Paginating Data
 You can paginate results by using the WithPagination trait.
 

--- a/src/Tags/Livewire.php
+++ b/src/Tags/Livewire.php
@@ -23,7 +23,7 @@ class Livewire extends Tags
         /**
          * Fetching all parameters from our livewire tag, to mount them as livewire parameters.
          */
-        $parameters = $this->params;
+        $parameters = $this->params->put('context', $this->context);
 
         /**
          * Let the Livewire magic happen.
@@ -68,8 +68,7 @@ class Livewire extends Tags
         $expression = $this->params->get('property');
         $instanceId = $this->context['_instance']->id;
 
-        if ((object) $expression instanceof \Livewire\WireDirective)
-        {
+        if ((object) $expression instanceof \Livewire\WireDirective) {
             $value = $expression->value();
             $modifier = $expression->hasModifier('defer') ? '.defer' : '';
 

--- a/src/WithContext.php
+++ b/src/WithContext.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jonassiewertsen\Livewire;
+
+trait WithContext
+{
+    public array $context;
+}


### PR DESCRIPTION
The idea of this PR is to make the Statamic context available as public property in your Livewire components. Having the context available can help to reduce the number of properties you have to pass down the component in your view.

Simply add the `WithContext` trait to your component and you're good to go.

I'm not completely sure, but one possible limitation is probably the reactivity of the context property. If you want to make certain context properties reactive, you'd still have to manually create a new livewire property and mount the context value to it. At least this would reduce the noise in your template.

Another idea could be to do some magic and automatically add all context properties as a livewire property. But this might lead to other issues as well.

Please give feedback on what you think about this idea.

