### PR TITLE
Fix Error when redirecting

### DIFF
--- a/src/Tags/Livewire.php
+++ b/src/Tags/Livewire.php
@@ -18,7 +18,7 @@ class Livewire extends Tags
      * @param $expression
      * @return mixed
      */
-    public function wildcard($expression): string
+    public function wildcard($expression)
     {
         /**
          * Fetching all parameters from our livewire tag, to mount them as livewire parameters.


### PR DESCRIPTION
Removed type casting from wildcard function to allow mixed types like redirects  