### PR TITLE
Allow Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0",
+        "illuminate/support": "^9.0 || ^10.0",
         "statamic/cms": "^4.0",
         "livewire/livewire": "^3.0"
     },


### PR DESCRIPTION
I think it's generally a good idea to follow Statamic's version constraints regarding Laravel. Statamic is compatible with both Laravel 9 and 10. I don't believe this addon uses any Laravel 10-only features. So it's a small thing to add while allowing anyone on Statamic 4+ to use this addon.