### PR TITLE
Fix Entry data hydration

### DIFF
--- a/src/Synthesizers/EntryCollectionSynthesizer.php
+++ b/src/Synthesizers/EntryCollectionSynthesizer.php
@@ -40,7 +40,8 @@ class EntryCollectionSynthesizer extends Synth
             $entry = Entry::make()
                 ->id($value['id'])
                 ->slug($value['slug'] ?? null)
-                ->collection($value['collection'] ?? null);
+                ->collection($value['collection'] ?? null)
+                ->data($value['data']);
 
             if ($value['date']) {
                 $entry->date($value['date'] ?? null);

--- a/src/Synthesizers/EntrySynthesizer.php
+++ b/src/Synthesizers/EntrySynthesizer.php
@@ -32,7 +32,8 @@ class EntrySynthesizer extends Synth
         $entry = Entry::make()
             ->id($value['id'])
             ->slug($value['slug'] ?? null)
-            ->collection($value['collection'] ?? null);
+            ->collection($value['collection'] ?? null)
+            ->data($value['data']);
 
         if ($value['date']) {
             $entry->date($value['date'] ?? null);


### PR DESCRIPTION
This PR fixes the entry data hydration in the `EntrySynthesizer` and `EntryCollectionSynthesizer`. Without this fix, the entry's data would be empty on subsequent component hydration.