### PR TITLE
Support component key

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,22 @@ class ShowContact extends Component
 }
 ```
 
-The [Official Livewire documentation](https://livewire.laravel.com/docs/components#rendering-components)
+The [Official Livewire documentation](https://livewire.laravel.com/docs/components#rendering-components) provides more information.
+
+### Keying Components
+Livewire components are automatically keyed by default. If you want to manually key a component, you can use the `key` attribute.
+```html
+<!-- If using Antlers -->
+{{ contacts }}
+    {{ livewire:your-component-name :key="id" }}
+{{ /contacts }}
+
+<!-- If using Blade -->
+@foreach ($contacts as $contact)
+    <livewire:your-component-name :key="$contact->id" />
+@endforeach
+```
+The [Official Livewire documentation](https://livewire.laravel.com/docs/components#adding-wirekey-to-foreach-loops) provides more information.
 
 ### Multi-Site
 When using Livewire in a Multi-Site context, the current site gets lost between requests. There is a trait (`\Jonassiewertsen\Livewire\RestoreCurrentSite`) to solve that. Just include it in your component and use `Site::current()` as you normally do.

--- a/src/Tags/Livewire.php
+++ b/src/Tags/Livewire.php
@@ -13,7 +13,7 @@ class Livewire extends Tags
      */
     public function wildcard($expression): string
     {
-        return \Livewire\Livewire::mount($expression, $this->params->toArray());
+        return \Livewire\Livewire::mount($expression, $this->params->except('key')->toArray(), $this->params->only('key')->first());
     }
 
     /**
@@ -46,7 +46,7 @@ class Livewire extends Tags
     {
         $instanceId = $this->context['__livewire']->getId();
 
-        if (! count($this->params)) {
+        if (!count($this->params)) {
             return "window.Livewire.find('{$instanceId}')";
         }
 

--- a/src/Tags/Livewire.php
+++ b/src/Tags/Livewire.php
@@ -46,7 +46,7 @@ class Livewire extends Tags
     {
         $instanceId = $this->context['__livewire']->getId();
 
-        if (!count($this->params)) {
+        if (! count($this->params)) {
             return "window.Livewire.find('{$instanceId}')";
         }
 


### PR DESCRIPTION
When rendering nested components in a loop, they get re-rendered every request. This can be solved by providing the `key` parameter.