### PR TITLE
Add support for static caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Visit my newest project Statamictutorials.com. Many tutorials are free.
 ## Description
 A third-party [Laravel Livewire](https://laravel-livewire.com/) integration for Statamic. 
 
-It's as easy as it get's to get stared with Livewire if using Statamic.
+It's as easy as it gets to get started with Livewire if using Statamic.
 
 ## Installation
 Pull in the Livewire package with composer
@@ -20,19 +20,8 @@ Pull in the Livewire package with composer
 composer require jonassiewertsen/statamic-livewire
 ```
 
-## Upgrade
-
-Make sure to read the Livewire upgarde guide, in case you're updating to `Statamic Livewire` 3, as there are breaking changes:
-https://livewire.laravel.com/docs/upgrading
-
-## General documentation
-[Livewire Docs](https://livewire.laravel.com/docs/quickstart)
-
-## Livewire scripts and styles
-
-Livewire injects its styles and scripts automatically into the page. However, this does not work if caching is enabled (`half`/`full`). In that case, you want to include them [manually](https://livewire.laravel.com/docs/installation#manually-including-livewires-frontend-assets), by using the respective tags `{{ livewire:styles }}` and`{{ livewire:scripts }}`.
-
-In case you need to include some custom Alpine plugins, you can [bundle the assets yourself](https://livewire.laravel.com/docs/installation#manually-bundling-livewire-and-alpine) and disable the automatic injection by using the `{{ livewire:scriptConfig }}` tag. Do not forget to include the `{{ livewire:styles }}` tag as well.
+### Manually including Livewire's frontend assets
+By default, Livewire injects the JavaScript and CSS assets it needs into each page that includes a Livewire component. If you want more control over this behavior, you can [manually include the assets](https://livewire.laravel.com/docs/installation#manually-including-livewires-frontend-assets) on a page using the following Antlers tags or Blade directives:
 
 ```html 
 <html>
@@ -47,13 +36,55 @@ In case you need to include some custom Alpine plugins, you can [bundle the asse
     
         ...
         <!-- If using Antlers -->
-        {{ livewire:scripts }} / {{ livewire:scriptConfig }}
+        {{ livewire:scripts }}
     
         <!-- Blade -->
-        @livewireScripts / @livewireScriptConfig
+        @livewireScripts
     </body>
 </html>
 ```
+
+### Manually bundling Livewire and Alpine
+If you need to include some custom Alpine plugins, you need to [manually bundle the Livewire and Alpine assets](https://livewire.laravel.com/docs/installation#manually-bundling-livewire-and-alpine) and disable the automatic injection by using the following Antlers tag or Blade directive. Do not forget to include the Livewire styles as well.
+
+```html 
+<html>
+    <head>
+        <!-- If using Antlers -->
+        {{ livewire:styles }}
+    
+        <!-- If using Blade -->
+        @livewireStyles
+    </head>
+    <body>
+    
+        ...
+        <!-- If using Antlers -->
+        {{ livewire:scriptConfig }}
+    
+        <!-- Blade -->
+        @livewireScriptConfig
+    </body>
+</html>
+```
+
+### Static caching
+If you use half or full static caching, add the `LivewireReplacer` to the `replacers` array. Make sure to add this replacer after the `CsrfTokenReplacer` replacer.
+
+```php
+'replacers' => [
+    \Statamic\StaticCaching\Replacers\CsrfTokenReplacer::class,
+    \Statamic\StaticCaching\Replacers\LivewireReplacer::class,
+],
+```
+
+## Upgrade
+
+Make sure to read the Livewire upgrade guide, in case you're updating to `Statamic Livewire` 3, as there are breaking changes:
+https://livewire.laravel.com/docs/upgrading
+
+## General documentation
+[Livewire Docs](https://livewire.laravel.com/docs/quickstart)
 
 ### Include components
 You can create Livewire components as described in the [general documentation](https://livewire.laravel.com/docs/components). 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,11 @@ If you need to include some custom Alpine plugins, you need to [manually bundle 
 ```
 
 ### Static caching
-If you use half or full static caching, add the `LivewireReplacer` to the `replacers` array. Make sure to add this replacer after the `CsrfTokenReplacer` replacer.
+This addon adds an `AssetsReplacer` class to make Livewire compatible with half and full static caching. You may customize the replacers in the config of this addon:
 
 ```php
 'replacers' => [
-    \Statamic\StaticCaching\Replacers\CsrfTokenReplacer::class,
-    \Statamic\StaticCaching\Replacers\LivewireReplacer::class,
+    \Jonassiewertsen\Livewire\Replacers\AssetsReplacer::class,
 ],
 ```
 

--- a/config/config.php
+++ b/config/config.php
@@ -29,4 +29,18 @@ return [
             \Jonassiewertsen\Livewire\Synthesizers\EntrySynthesizer::class,
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Replacers
+    |--------------------------------------------------------------------------
+    |
+    | Define the replacers that will be used when static caching is enabled
+    | to dynamically replace content within the response.
+    |
+    */
+
+    'replacers' => [
+        \Jonassiewertsen\Livewire\Replacers\AssetsReplacer::class,
+    ],
 ];

--- a/src/LivewireReplacer.php
+++ b/src/LivewireReplacer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jonassiewertsen\Livewire;
+
+use Illuminate\Http\Response;
+use Livewire\Features\SupportAutoInjectedAssets\SupportAutoInjectedAssets;
+use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
+use Statamic\StaticCaching\Replacer;
+
+class LivewireReplacer implements Replacer
+{
+    public function prepareResponseToCache(Response $responseToBeCached, Response $initialResponse)
+    {
+        if (! $content = $responseToBeCached->getContent()) {
+            return;
+        }
+
+        if (! $assets = SupportScriptsAndAssets::getAssets()) {
+            return;
+        }
+
+        $assetsHead = implode('', $assets);
+        $assetsBody = '';
+
+        $responseToBeCached->setContent(
+            SupportAutoInjectedAssets::injectAssets($content, $assetsHead, $assetsBody)
+        );
+    }
+
+    public function replaceInCachedResponse(Response $response)
+    {
+        //
+    }
+}

--- a/src/LivewireReplacer.php
+++ b/src/LivewireReplacer.php
@@ -21,11 +21,12 @@ class LivewireReplacer implements Replacer
             return;
         }
 
-        $assetsHead = implode('', $assets);
-        $assetsBody = '';
-
         $responseToBeCached->setContent(
-            SupportAutoInjectedAssets::injectAssets($content, $assetsHead, $assetsBody)
+            SupportAutoInjectedAssets::injectAssets(
+                html: $content,
+                assetsHead: implode('', $assets),
+                assetsBody: ''
+            )
         );
     }
 

--- a/src/LivewireReplacer.php
+++ b/src/LivewireReplacer.php
@@ -3,8 +3,10 @@
 namespace Jonassiewertsen\Livewire;
 
 use Illuminate\Http\Response;
+use Illuminate\Support\Str;
 use Livewire\Features\SupportAutoInjectedAssets\SupportAutoInjectedAssets;
 use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
+use Livewire\Mechanisms\FrontendAssets\FrontendAssets;
 use Statamic\StaticCaching\Replacer;
 
 class LivewireReplacer implements Replacer
@@ -29,6 +31,16 @@ class LivewireReplacer implements Replacer
 
     public function replaceInCachedResponse(Response $response)
     {
-        //
+        if (Str::contains($response, app(FrontendAssets::class)->scripts())) {
+            return;
+        }
+
+        if (Str::contains($response, app(FrontendAssets::class)->scriptConfig())) {
+            return;
+        }
+
+        app(FrontendAssets::class)->hasRenderedScripts = false;
+
+        app('livewire')->forceAssetInjection();
     }
 }

--- a/src/Replacers/AssetsReplacer.php
+++ b/src/Replacers/AssetsReplacer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Jonassiewertsen\Livewire;
+namespace Jonassiewertsen\Livewire\Replacers;
 
 use Illuminate\Http\Response;
 use Illuminate\Support\Str;
@@ -9,7 +9,7 @@ use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
 use Livewire\Mechanisms\FrontendAssets\FrontendAssets;
 use Statamic\StaticCaching\Replacer;
 
-class LivewireReplacer implements Replacer
+class AssetsReplacer implements Replacer
 {
     public function prepareResponseToCache(Response $responseToBeCached, Response $initialResponse)
     {

--- a/src/Replacers/AssetsReplacer.php
+++ b/src/Replacers/AssetsReplacer.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Str;
 use Livewire\Features\SupportAutoInjectedAssets\SupportAutoInjectedAssets;
 use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
+use Livewire\Livewire;
 use Livewire\Mechanisms\FrontendAssets\FrontendAssets;
 use Statamic\StaticCaching\Replacer;
 
@@ -32,16 +33,16 @@ class AssetsReplacer implements Replacer
 
     public function replaceInCachedResponse(Response $response)
     {
-        if (Str::contains($response, app(FrontendAssets::class)->scripts())) {
+        if (Str::contains($response, FrontendAssets::scripts())) {
             return;
         }
 
-        if (Str::contains($response, app(FrontendAssets::class)->scriptConfig())) {
+        if (Str::contains($response, FrontendAssets::scriptConfig())) {
             return;
         }
 
         app(FrontendAssets::class)->hasRenderedScripts = false;
 
-        app('livewire')->forceAssetInjection();
+        Livewire::forceAssetInjection();
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,10 +13,8 @@ class ServiceProvider extends AddonServiceProvider
         'Jonassiewertsen\Livewire\Tags\Livewire',
     ];
 
-    public function boot(): void
+    public function bootAddon(): void
     {
-        parent::boot();
-
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'statamic-livewire');
 
         if ($this->app->runningInConsole()) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Jonassiewertsen\Livewire;
 
 use Livewire\Livewire;
-use Statamic\StaticCaching\Replacer;
 use Statamic\Providers\AddonServiceProvider;
 
 class ServiceProvider extends AddonServiceProvider

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Jonassiewertsen\Livewire;
 
 use Livewire\Livewire;
+use Statamic\StaticCaching\Replacer;
 use Statamic\Providers\AddonServiceProvider;
 
 class ServiceProvider extends AddonServiceProvider
@@ -23,10 +24,19 @@ class ServiceProvider extends AddonServiceProvider
             ], 'statamic-livewire');
         }
 
+        $this->bootReplacers();
         $this->bootSyntesizers();
     }
 
-    protected function bootSyntesizers()
+    protected function bootReplacers(): void
+    {
+        config()->set('statamic.static_caching.replacers', array_merge(
+            config('statamic.static_caching.replacers'),
+            config('statamic-livewire.replacers')
+        ));
+    }
+
+    protected function bootSyntesizers(): void
     {
         if (! config('statamic-livewire.synthesizers.enabled', false)) {
             return;


### PR DESCRIPTION
This PR adds a new `AssetsReplacer` class to make Livewire compatible with Statamic's static caching. The replacer is merged with existing replacers and loaded automatically. Users may swap the replacer class with their own implementation or add additional replacers in the config.

```php
/*
|--------------------------------------------------------------------------
| Replacers
|--------------------------------------------------------------------------
|
| Define the replacers that will be used when static caching is enabled
| to dynamically replace content within the response.
|
*/

'replacers' => [
    \Jonassiewertsen\Livewire\Replacers\AssetsReplacer::class,
],
```

The `AssetsReplacer` adds support …

- … for automatic injection of Livewire scripts and styles. Previously, you had to manually include the Livewire assets when using static caching.
- … for Livewire's [`@assets` Blade directive](https://livewire.laravel.com/docs/javascript#loading-assets). Without this PR, the assets wouldn't be pushed to the head at all.