### PR TITLE
Add more synthesizers

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -27,6 +27,7 @@ return [
         'classes' => [
             \Jonassiewertsen\Livewire\Synthesizers\EntryCollectionSynthesizer::class,
             \Jonassiewertsen\Livewire\Synthesizers\EntrySynthesizer::class,
+            \Jonassiewertsen\Livewire\Synthesizers\FieldtypeSynthesizer::class,
             \Jonassiewertsen\Livewire\Synthesizers\ValueSynthesizer::class,
         ],
     ],

--- a/config/config.php
+++ b/config/config.php
@@ -27,6 +27,7 @@ return [
         'classes' => [
             \Jonassiewertsen\Livewire\Synthesizers\EntryCollectionSynthesizer::class,
             \Jonassiewertsen\Livewire\Synthesizers\EntrySynthesizer::class,
+            \Jonassiewertsen\Livewire\Synthesizers\FieldSynthesizer::class,
             \Jonassiewertsen\Livewire\Synthesizers\FieldtypeSynthesizer::class,
             \Jonassiewertsen\Livewire\Synthesizers\ValueSynthesizer::class,
         ],

--- a/config/config.php
+++ b/config/config.php
@@ -27,6 +27,7 @@ return [
         'classes' => [
             \Jonassiewertsen\Livewire\Synthesizers\EntryCollectionSynthesizer::class,
             \Jonassiewertsen\Livewire\Synthesizers\EntrySynthesizer::class,
+            \Jonassiewertsen\Livewire\Synthesizers\ValueSynthesizer::class,
         ],
     ],
 

--- a/src/Synthesizers/FieldSynthesizer.php
+++ b/src/Synthesizers/FieldSynthesizer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Jonassiewertsen\Livewire\Synthesizers;
+
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+use Statamic\Fields\Field;
+
+class FieldSynthesizer extends Synth
+{
+    public static $key = 'statamic-field';
+
+    public static function match($target)
+    {
+        return $target instanceof Field;
+    }
+
+    public function dehydrate($target, $dehydrateChild)
+    {
+        $data = [
+            'handle' => $target->handle(),
+            'config' => $target->config(),
+        ];
+
+        foreach ($data as $key => $child) {
+            $data[$key] = $dehydrateChild($key, $child);
+        }
+
+        return [$data, []];
+    }
+
+    public function hydrate($value, $meta, $hydrateChild)
+    {
+        foreach ($value as $key => $child) {
+            $value[$key] = $hydrateChild($key, $child);
+        }
+
+        return new Field(...$value);
+    }
+}

--- a/src/Synthesizers/FieldtypeSynthesizer.php
+++ b/src/Synthesizers/FieldtypeSynthesizer.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jonassiewertsen\Livewire\Synthesizers;
+
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+use Statamic\Fields\Fieldtype;
+
+class FieldtypeSynthesizer extends Synth
+{
+    public static $key = 'statamic-fieldtype';
+
+    public static function match($target)
+    {
+        return $target instanceof Fieldtype;
+    }
+
+    public function dehydrate($target, $dehydrateChild)
+    {
+        $data = [
+            'field' => $target->field(),
+        ];
+
+        foreach ($data as $key => $child) {
+            $data[$key] = $dehydrateChild($key, $child);
+        }
+
+        return [
+            $data,
+            ['class' => get_class($target)],
+        ];
+    }
+
+    public function hydrate($value, $meta, $hydrateChild)
+    {
+        foreach ($value as $key => $child) {
+            $value[$key] = $hydrateChild($key, $child);
+        }
+
+        return app($meta['class'])->setField($value['field']);
+    }
+}

--- a/src/Synthesizers/ValueSynthesizer.php
+++ b/src/Synthesizers/ValueSynthesizer.php
@@ -25,7 +25,7 @@ class ValueSynthesizer extends Synth
             'handle' => $value->handle,
             'fieldtype' => $value->fieldtype,
             'augmentable' => $value->augmentable,
-            'shallow' =>  $value->shallow,
+            'shallow' => $value->shallow,
         ];
 
         foreach ($data as $key => $child) {

--- a/src/Synthesizers/ValueSynthesizer.php
+++ b/src/Synthesizers/ValueSynthesizer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Jonassiewertsen\Livewire\Synthesizers;
+
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+use Statamic\Fields\Value;
+
+use function Livewire\invade;
+
+class ValueSynthesizer extends Synth
+{
+    public static $key = 'statamic-value';
+
+    public static function match($target)
+    {
+        return $target instanceof Value;
+    }
+
+    public function dehydrate($target, $dehydrateChild)
+    {
+        $value = invade($target);
+
+        $data = [
+            'value' => $value->raw,
+            'handle' => $value->handle,
+            'fieldtype' => $value->fieldtype,
+            'augmentable' => $value->augmentable,
+            'shallow' =>  $value->shallow,
+        ];
+
+        foreach ($data as $key => $child) {
+            $data[$key] = $dehydrateChild($key, $child);
+        }
+
+        return [$data, []];
+    }
+
+    public function hydrate($value, $meta, $hydrateChild)
+    {
+        foreach ($value as $key => $child) {
+            $value[$key] = $hydrateChild($key, $child);
+        }
+
+        return new Value(...$value);
+    }
+}


### PR DESCRIPTION
This PR builds on top of the existing synthesizers and adds support for `Statamic\Fields\Value` as a public property.

```php
public Value $value;

public function mount()
{
    $this->value = Entry::all()->first()->augmentedValue('bard');
}
```

I've also added synthesizers for `Statamic\Fields\Fieldtype` and `Statamic\Fields\Field` as those are necessary to properly dehydrate and hydrate a `Statamic\Fields\Value`.

This PR should close #58. Maybe @edalzell can chip in if this PR solves his needs.