### PR TITLE
Allow for dynamic component names

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ To include your Livewire component:
 </body>
 ```
 
+if you want to include a component from a dynamic variable you can use the `livewire:component` tag:
+
+```html
+<body>
+    <!-- If using Antlers -->
+    {{ livewire:component :name="variable" }}
+
+    <!-- If using Blade -->
+    <livewire:component name="$variable" />
+</body>
+```
+
 ### Blade or Antlers? Both!
 If creating a Livewire component, you need to render a template file
 

--- a/src/Tags/Livewire.php
+++ b/src/Tags/Livewire.php
@@ -15,6 +15,16 @@ class Livewire extends Tags
     {
         return \Livewire\Livewire::mount($expression, $this->params->except('key')->toArray(), $this->params->only('key')->first());
     }
+    
+    /**
+     * This will load your Livewire component in the Antlers view
+     *
+     * {{ livewire:component name="my-component" }}
+     */
+    public function component(): string
+    {
+        return $this->wildcard($this->params->pull('name'));
+    }
 
     /**
      * Sharing State Between Livewire And Alpine via entangle.


### PR DESCRIPTION
This PR adds a new tag `{{ livewire:component name="my-component-name" }}` so that you can pass dynamic component names.